### PR TITLE
spike: evaluate Pydantic + FastAPI + OpenAPI->Elm as a Protobuf replacement

### DIFF
--- a/spike/openapi-elm/.gitignore
+++ b/spike/openapi-elm/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+elm-stuff/
+venv/
+node_modules/

--- a/spike/openapi-elm/FINDINGS.md
+++ b/spike/openapi-elm/FINDINGS.md
@@ -1,0 +1,193 @@
+# Spike: is Protobuf -> Pydantic + FastAPI + OpenAPI->Elm viable?
+
+**Verdict: yes, the Elm generator is good enough. Phase 3 is viable.**
+
+This spike exists to answer one question before any migration work starts: when
+we throw away `protoc-gen-elm`, is what we get back at least as good? The whole
+API in `protobuf/mvp.proto` is built on `oneof` Ok/Error result types, and
+`oneof` is the thing OpenAPI generators historically handle worst. If the
+generated Elm couldn't express that as a real custom type, the migration would
+be a downgrade and should not happen.
+
+It can. Everything below is reproducible with `./run.sh`.
+
+## What was tested
+
+The `LogInUsername` slice, chosen because it transitively exercises every proto
+feature the rest of the API relies on:
+
+| proto feature | where |
+| --- | --- |
+| `oneof` Ok/Error result | `LogInUsernameResponse` — the crux |
+| nested `message Error` | `LogInUsernameResponse.Error` |
+| `bytes` | `AuthToken.hmac_of_rest`, `HashedPassword.salt`/`.scrypt` |
+| `map<string, X>` | `GenericUserInfo.invitations`, `.relationships` |
+| second `oneof` | `GenericUserInfo.login_type` |
+| empty message | `GenericUserInfo.Invitation` |
+
+Tooling: pydantic 2.13, FastAPI 0.139, [`elm-open-api`](https://github.com/wolfadex/elm-open-api)
+(**not** `openapi-generator`'s dated Elm target), elm 0.19.1 — the version the
+repo pins.
+
+The test is genuinely end-to-end, not a schema inspection: `app.py` is a real
+FastAPI app, its real HTTP responses are captured verbatim into
+`sample_ok.json` / `sample_err.json`, and `elm-check/tests/RoundTripTest.elm`
+feeds exactly those bytes to the generated decoders. **4/4 passing**, compiled
+with elm 0.19.1.
+
+## The good news
+
+The `oneof` comes out as a real Elm custom type you can `case` on:
+
+```elm
+type LogInUsernameResultError_Or_LogInUsernameResultOk
+    = LogInUsernameResultError_Or_LogInUsernameResultOk__LogInUsernameResultError LogInUsernameResultError
+    | LogInUsernameResultError_Or_LogInUsernameResultOk__LogInUsernameResultOk   LogInUsernameResultOk
+```
+
+Dispatch is correct, and not by accident. The generator emits
+`Json.Decode.oneOf [try Error, try Ok]` — try-in-order rather than a
+discriminator lookup, which looks alarming — but each arm's decoder independently
+validates its own discriminator literal (`if andThenUnpack == "ok" then ... else
+Json.Decode.fail`). So it is genuinely discriminated, just implemented by
+backtracking. It does not rely on the arms happening to have disjoint fields.
+
+**One real improvement over the status quo.** Today's protobuf Elm is:
+
+```elm
+type alias LogInUsernameResponse =
+    { logInUsernameResult : Maybe LogInUsernameResult }   -- Maybe!
+```
+
+That `Maybe` is why all 18 `simplify*Response` helpers in `elm/src/API.elm` carry
+a dead arm: `Nothing -> Err "Invalid server response (neither Ok nor Error in
+protobuf)"`. Under OpenAPI the response *is* the union — no `Maybe`, no
+impossible state, and those 18 dead arms delete themselves.
+
+## The cost
+
+**Constructor names are ugly and can't be fixed by the generator.** Wrapping the
+union in a pydantic `RootModel` gets you `type alias LogInUsernameResponse =
+LogInUsernameResultError_Or_LogInUsernameResultOk`, which fixes the *type* name —
+but the *constructors* keep the long form, and you `case` on constructors, so the
+noise lands at every use site. Mitigation: a thin hand-written adapter mapping
+the generated union to a clean local type. That is precisely what `API.elm`'s
+`simplify*Response` functions already do today, so this is a rewrite of an
+existing layer, not a new one.
+
+**One extra field hop.** Protobuf attaches the payload straight to the
+constructor (`LogInUsernameResultOk AuthSuccess`); OpenAPI attaches the wrapper
+record, so it's `r.ok` rather than `r`. Minor, but it touches every call site.
+
+**FastAPI's 422 machinery leaks into the generated Elm** as `HTTPValidationError`,
+`ValidationError`, and an `Int_Or_String` union. Cosmetic noise, but it's in the
+public API of the generated module.
+
+## Landmines found (these change the Phase 1 advice)
+
+### 1. `pydantic.Base64Bytes` silently corrupts data. Do not use it.
+
+This is the big one, and it directly contradicts the "just use `Base64Bytes`"
+advice from the original writeup. Its semantics are **inverted**: it base64-
+*decodes* on validation, so handing it raw bytes from Python mangles them:
+
+```python
+class M(BaseModel): b: Base64Bytes
+M(b=b'\xde\xad\xbe\xef').b   # == b''   -- no error raised
+M(b=b'abc!')                 # ValidationError  -- inconsistent!
+```
+
+Whether you get silent corruption or a loud error depends on whether your random
+bytes happen to be valid base64. `core.new_hashed_password()` does exactly this
+with `secrets.token_bytes(4)`, so a naive port would silently store empty salts
+for a fraction of users — an auth bug that no test would catch unless it asserted
+on the salt.
+
+The working pattern is in `models.py` as `ProtoBytes`: keep `bytes` as the
+Python-side type, base64 only at the JSON boundary via
+`BeforeValidator`/`PlainSerializer`. Verified to round-trip
+`b'\x00\x01\xfe\xff\x80'` intact.
+
+### 2. Use `format: byte`, not `format: base64`.
+
+`Base64Bytes` advertises `format: base64`, which `elm-open-api` doesn't recognise —
+it warns and degrades the field to `String`. Declaring `format: byte` (via
+`WithJsonSchema`) gets real `Bytes.Bytes` in Elm, matching today's protobuf types
+exactly, with zero warnings. `ProtoBytes` does this.
+
+Note this needs `danfishgold/base64-bytes` in `elm.json` — which the repo
+**already** depends on. No new Elm dependency.
+
+### 3. Defaults become `Maybe`s. Make wire fields required.
+
+A pydantic field with a default is omitted from OpenAPI `required`, and the
+generator wraps it in `Maybe`. A defaulted *and* nullable field gets you a
+`Maybe (Nullable ...)` double-option. Dropping the defaults:
+
+```elm
+-- with `= Field(default_factory=dict)` / `= None`
+{ invitations : Maybe (Dict.Dict String Invitation)
+, login_type  : Maybe (OpenApi.Common.Nullable LoginTypePassword) }
+
+-- required (no default)
+{ invitations : Dict.Dict String Invitation
+, login_type  : OpenApi.Common.Nullable LoginTypePassword }
+```
+
+Costs the server an explicit `invitations={}`; buys the Elm side a pile of
+deleted `Maybe`-unwrapping. Today's protobuf Elm is *worse* here — it generates
+`Dict String (Maybe GenericUserInfoInvitation)`, with a pointless `Maybe` inside
+the dict.
+
+### 4. `alias_generator=to_camel` avoids renaming every field in 5,253 lines of Elm.
+
+By default the generated Elm keeps snake_case field names (`email_address`), but
+today's protobuf Elm is camelCase (`emailAddress`). That diff would touch every
+field access in the entire Elm codebase for no benefit. Setting
+`ConfigDict(alias_generator=to_camel, populate_by_name=True)` emits camelCase JSON
+while keeping snake_case on the Python side, so today's Elm field names survive
+untouched and the JSON is idiomatic. Verified; not yet applied to `models.py`
+(it would obscure the plain-mapping demo).
+
+### 5. Set `operation_id` explicitly.
+
+Without it, FastAPI derives one from function name + path + method and the
+generator produces `logInUsernameApiLogInUsernamePost`. With
+`operation_id="logInUsername"` you get `logInUsername`.
+
+## Recommendation
+
+Phase 3 is viable — proceed with the phased plan. The generator clears the bar,
+and on the `Maybe`-wrapped-union and `Maybe`-inside-`Dict` points it beats
+`protoc-gen-elm`. The residual cost is ugly constructor names, addressed by an
+adapter layer that already exists in spirit.
+
+The `Base64Bytes` landmine is the most valuable thing here, and it is a **Phase 1**
+concern — it bites the moment `HashedPassword` and `AuthToken` become Pydantic
+models, long before any Elm is regenerated. Whoever does Phase 1 should read
+finding #1 first.
+
+## Layout
+
+| path | what |
+| --- | --- |
+| `models.py` | hand-written Pydantic translation of the proto slice |
+| `app.py` | the FastAPI app (canned handler; the point is the wire shape) |
+| `gen_openapi.py` | dumps `openapi.json` |
+| `openapi.json` | **generated** — committed so the oneOf/discriminator is reviewable |
+| `sample_ok.json`, `sample_err.json` | **generated** — real captured HTTP responses |
+| `elm-check/src/` | **generated** by `elm-open-api` — committed so the output is reviewable in the diff |
+| `elm-check/tests/RoundTripTest.elm` | hand-written; the actual test |
+| `run.sh` | reproduces all of the above from scratch |
+
+Nothing here is wired into `dodo.py` or the real build. The whole directory is
+throwaway and should be deleted once the migration decision is acted on.
+
+## Not covered
+
+- The recursive `ResolutionEvent.prior_revision` — pydantic handles self-reference,
+  but the Elm generator's output for it is unverified. Worth a follow-up probe.
+- `SavedCreatedPredictionFormState` in localStorage (`CreatePrediction.elm:290`).
+- The SSR bootstrap path (`web_server.pb_b64` -> Elm flags).
+- Token/cookie signing and `ProofOfEmail` — deliberately out of scope; these are
+  Phase 1 concerns and don't depend on the generator.

--- a/spike/openapi-elm/app.py
+++ b/spike/openapi-elm/app.py
@@ -1,0 +1,58 @@
+"""Minimal FastAPI app exposing the LogInUsername slice.
+
+Serves two purposes:
+  - `python gen_openapi.py` emits openapi.json for the Elm generator.
+  - running it for real produces genuine on-the-wire JSON, which the generated
+    Elm decoders are then tested against (see elm-test/tests/RoundTripTest.elm).
+
+The handler returns canned data; the point is the serialized shape, not the
+business logic.
+"""
+
+from fastapi import FastAPI
+
+from models import (
+    AuthSuccess,
+    AuthToken,
+    GenericUserInfo,
+    HashedPassword,
+    Invitation,
+    LogInUsernameError,
+    LogInUsernameRequest,
+    LogInUsernameResponse,
+    LogInUsernameResultError,
+    LogInUsernameResultOk,
+    LoginTypePassword,
+    Relationship,
+)
+
+app = FastAPI(title="biatob (LogInUsername spike)", version="0.0.1")
+
+
+# operation_id matters: without it FastAPI derives one from the function name +
+# path + method, and the Elm generator turns that into the function name
+# `logInUsernameApiLogInUsernamePost`. Setting it explicitly gets `logInUsername`.
+@app.post("/api/LogInUsername", response_model=LogInUsernameResponse, operation_id="logInUsername")
+def log_in_username(request: LogInUsernameRequest) -> LogInUsernameResponse:
+    if request.password != "hunter2":
+        return LogInUsernameResultError(error=LogInUsernameError(catchall="bad password"))
+
+    return LogInUsernameResultOk(
+        ok=AuthSuccess(
+            token=AuthToken(
+                # Deliberately non-UTF8 bytes: this is what breaks plain `bytes`.
+                hmac_of_rest=b"\x00\x01\xfe\xff\x80",
+                owner=request.username,
+                minted_unixtime=1600000000.0,
+                expires_unixtime=1600086400.0,
+            ),
+            user_info=GenericUserInfo(
+                email_address="spike@example.com",
+                invitations={"some-nonce": Invitation()},
+                relationships={"alice": Relationship(trusts_you=True, trusted_by_you=False)},
+                login_type=LoginTypePassword(
+                    login_password=HashedPassword(salt=b"\xde\xad\xbe\xef", scrypt=b"\x01\x02\x03"),
+                ),
+            ),
+        ),
+    )

--- a/spike/openapi-elm/elm-check/elm.json
+++ b/spike/openapi-elm/elm-check/elm.json
@@ -1,0 +1,25 @@
+{
+    "type": "application",
+    "source-directories": [ "src" ],
+    "elm-version": "0.19.1",
+    "dependencies": {
+        "direct": {
+            "danfishgold/base64-bytes": "1.1.0",
+            "elm/bytes": "1.0.8",
+            "elm/core": "1.0.5",
+            "elm/http": "2.0.0",
+            "elm/json": "1.1.3",
+            "elm/regex": "1.0.0",
+            "elm/time": "1.0.0",
+            "elm/url": "1.0.0",
+            "elm-explorations/test": "2.2.0"
+        },
+        "indirect": {
+            "elm/file": "1.0.5",
+            "elm/random": "1.0.0",
+            "elm/virtual-dom": "1.0.2",
+            "elm/html": "1.0.0"
+        }
+    },
+    "test-dependencies": { "direct": {}, "indirect": {} }
+}

--- a/spike/openapi-elm/elm-check/src/Api/Api.elm
+++ b/spike/openapi-elm/elm-check/src/Api/Api.elm
@@ -1,0 +1,78 @@
+module Api.Api exposing ( logInUsername, logInUsernameTask )
+
+{-|
+## Operations
+
+@docs logInUsername, logInUsernameTask
+-}
+
+
+import Api.Json
+import Api.Types
+import Dict
+import Http
+import Json.Decode
+import Json.Encode
+import OpenApi.Common
+import Task
+import Url.Builder
+
+
+{-| Log In Username -}
+logInUsername :
+    { toMsg :
+        Result (OpenApi.Common.Error Api.Types.HTTPValidationError String) Api.Types.LogInUsernameResultError_Or_LogInUsernameResultOk
+        -> msg
+    , body : Api.Types.LogInUsernameRequest
+    }
+    -> Cmd msg
+logInUsername config =
+    Http.request
+        { url = Url.Builder.absolute [ "api", "LogInUsername" ] []
+        , method = "POST"
+        , headers = []
+        , expect =
+            OpenApi.Common.expectJsonCustom
+                (Dict.fromList [ ( "422", Api.Json.decodeHTTPValidationError ) ]
+                )
+                (Json.Decode.oneOf
+                     [ Json.Decode.map
+                         Api.Types.LogInUsernameResultError_Or_LogInUsernameResultOk__LogInUsernameResultError
+                         Api.Json.decodeLogInUsernameResultError
+                     , Json.Decode.map
+                         Api.Types.LogInUsernameResultError_Or_LogInUsernameResultOk__LogInUsernameResultOk
+                         Api.Json.decodeLogInUsernameResultOk
+                     ]
+                )
+                config.toMsg
+        , body = Http.jsonBody (Api.Json.encodeLogInUsernameRequest config.body)
+        , timeout = Nothing
+        , tracker = Nothing
+        }
+
+
+{-| Log In Username -}
+logInUsernameTask :
+    { body : Api.Types.LogInUsernameRequest }
+    -> Task.Task (OpenApi.Common.Error Api.Types.HTTPValidationError String) Api.Types.LogInUsernameResultError_Or_LogInUsernameResultOk
+logInUsernameTask config =
+    Http.task
+        { url = Url.Builder.absolute [ "api", "LogInUsername" ] []
+        , method = "POST"
+        , headers = []
+        , resolver =
+            OpenApi.Common.jsonResolverCustom
+                (Dict.fromList [ ( "422", Api.Json.decodeHTTPValidationError ) ]
+                )
+                (Json.Decode.oneOf
+                     [ Json.Decode.map
+                         Api.Types.LogInUsernameResultError_Or_LogInUsernameResultOk__LogInUsernameResultError
+                         Api.Json.decodeLogInUsernameResultError
+                     , Json.Decode.map
+                         Api.Types.LogInUsernameResultError_Or_LogInUsernameResultOk__LogInUsernameResultOk
+                         Api.Json.decodeLogInUsernameResultOk
+                     ]
+                )
+        , body = Http.jsonBody (Api.Json.encodeLogInUsernameRequest config.body)
+        , timeout = Nothing
+        }

--- a/spike/openapi-elm/elm-check/src/Api/Json.elm
+++ b/spike/openapi-elm/elm-check/src/Api/Json.elm
@@ -1,0 +1,445 @@
+module Api.Json exposing
+    ( encodeAuthSuccess, encodeAuthToken, encodeGenericUserInfo, encodeHTTPValidationError, encodeHashedPassword, encodeInvitation, encodeLogInUsernameError
+    , encodeLogInUsernameRequest, encodeLogInUsernameResultError, encodeLogInUsernameResultOk, encodeLoginTypePassword, encodeRelationship, encodeValidationError
+    , decodeAuthSuccess, decodeAuthToken, decodeGenericUserInfo, decodeHTTPValidationError, decodeHashedPassword, decodeInvitation, decodeLogInUsernameError
+    , decodeLogInUsernameRequest, decodeLogInUsernameResultError, decodeLogInUsernameResultOk, decodeLoginTypePassword, decodeRelationship, decodeValidationError
+    )
+
+{-|
+## Encoders
+
+@docs encodeAuthSuccess, encodeAuthToken, encodeGenericUserInfo, encodeHTTPValidationError, encodeHashedPassword, encodeInvitation
+@docs encodeLogInUsernameError, encodeLogInUsernameRequest, encodeLogInUsernameResultError, encodeLogInUsernameResultOk, encodeLoginTypePassword, encodeRelationship
+@docs encodeValidationError
+
+## Decoders
+
+@docs decodeAuthSuccess, decodeAuthToken, decodeGenericUserInfo, decodeHTTPValidationError, decodeHashedPassword, decodeInvitation
+@docs decodeLogInUsernameError, decodeLogInUsernameRequest, decodeLogInUsernameResultError, decodeLogInUsernameResultOk, decodeLoginTypePassword, decodeRelationship
+@docs decodeValidationError
+-}
+
+
+import Api.Types
+import Bytes
+import Dict
+import Json.Decode
+import Json.Encode
+import OpenApi.Common
+
+
+encodeAuthSuccess : Api.Types.AuthSuccess -> Json.Encode.Value
+encodeAuthSuccess rec =
+    Json.Encode.object
+        [ ( "token", encodeAuthToken rec.token )
+        , ( "user_info", encodeGenericUserInfo rec.user_info )
+        ]
+
+
+encodeAuthToken : Api.Types.AuthToken -> Json.Encode.Value
+encodeAuthToken rec =
+    Json.Encode.object
+        [ ( "expires_unixtime", Json.Encode.float rec.expires_unixtime )
+        , ( "hmac_of_rest", OpenApi.Common.encodeStringByte rec.hmac_of_rest )
+        , ( "minted_unixtime", Json.Encode.float rec.minted_unixtime )
+        , ( "owner", Json.Encode.string rec.owner )
+        ]
+
+
+encodeGenericUserInfo : Api.Types.GenericUserInfo -> Json.Encode.Value
+encodeGenericUserInfo rec =
+    Json.Encode.object
+        [ ( "email_address", Json.Encode.string rec.email_address )
+        , ( "invitations"
+          , Json.Encode.dict Basics.identity encodeInvitation rec.invitations
+          )
+        , ( "login_type"
+          , case rec.login_type of
+                OpenApi.Common.Null ->
+                    Json.Encode.null
+            
+                OpenApi.Common.Present value ->
+                    encodeLoginTypePassword value
+          )
+        , ( "relationships"
+          , Json.Encode.dict
+                Basics.identity
+                encodeRelationship
+                rec.relationships
+          )
+        ]
+
+
+encodeHTTPValidationError : Api.Types.HTTPValidationError -> Json.Encode.Value
+encodeHTTPValidationError rec =
+    Json.Encode.object
+        (List.filterMap
+             Basics.identity
+             [ Maybe.map
+                 (\mapUnpack ->
+                    ( "detail"
+                    , Json.Encode.list encodeValidationError mapUnpack
+                    )
+                 )
+                 rec.detail
+             ]
+        )
+
+
+encodeHashedPassword : Api.Types.HashedPassword -> Json.Encode.Value
+encodeHashedPassword rec =
+    Json.Encode.object
+        [ ( "salt", OpenApi.Common.encodeStringByte rec.salt )
+        , ( "scrypt", OpenApi.Common.encodeStringByte rec.scrypt )
+        ]
+
+
+encodeInvitation : Api.Types.Invitation -> Json.Encode.Value
+encodeInvitation rec =
+    Json.Encode.object []
+
+
+encodeLogInUsernameError : Api.Types.LogInUsernameError -> Json.Encode.Value
+encodeLogInUsernameError rec =
+    Json.Encode.object [ ( "catchall", Json.Encode.string rec.catchall ) ]
+
+
+encodeLogInUsernameRequest : Api.Types.LogInUsernameRequest -> Json.Encode.Value
+encodeLogInUsernameRequest rec =
+    Json.Encode.object
+        [ ( "password", Json.Encode.string rec.password )
+        , ( "username", Json.Encode.string rec.username )
+        ]
+
+
+encodeLogInUsernameResultError :
+    Api.Types.LogInUsernameResultError -> Json.Encode.Value
+encodeLogInUsernameResultError rec =
+    Json.Encode.object
+        (List.filterMap
+             Basics.identity
+             [ Just ( "error", encodeLogInUsernameError rec.error )
+             , Maybe.map
+                 (\mapUnpack ->
+                    ( "log_in_username_result", Json.Encode.string mapUnpack )
+                 )
+                 rec.log_in_username_result
+             ]
+        )
+
+
+encodeLogInUsernameResultOk :
+    Api.Types.LogInUsernameResultOk -> Json.Encode.Value
+encodeLogInUsernameResultOk rec =
+    Json.Encode.object
+        (List.filterMap
+             Basics.identity
+             [ Maybe.map
+                 (\mapUnpack ->
+                    ( "log_in_username_result", Json.Encode.string mapUnpack )
+                 )
+                 rec.log_in_username_result
+             , Just ( "ok", encodeAuthSuccess rec.ok )
+             ]
+        )
+
+
+encodeLoginTypePassword : Api.Types.LoginTypePassword -> Json.Encode.Value
+encodeLoginTypePassword rec =
+    Json.Encode.object
+        (List.filterMap
+             Basics.identity
+             [ Just
+                 ( "login_password", encodeHashedPassword rec.login_password )
+             , Maybe.map
+                 (\mapUnpack ->
+                    ( "login_type_kind", Json.Encode.string mapUnpack )
+                 )
+                 rec.login_type_kind
+             ]
+        )
+
+
+encodeRelationship : Api.Types.Relationship -> Json.Encode.Value
+encodeRelationship rec =
+    Json.Encode.object
+        [ ( "trusted_by_you", Json.Encode.bool rec.trusted_by_you )
+        , ( "trusts_you", Json.Encode.bool rec.trusts_you )
+        ]
+
+
+encodeValidationError : Api.Types.ValidationError -> Json.Encode.Value
+encodeValidationError rec =
+    Json.Encode.object
+        (List.filterMap
+             Basics.identity
+             [ Maybe.map
+                 (\mapUnpack -> ( "ctx", Json.Encode.object [] ))
+                 rec.ctx
+             , Maybe.map
+                 (\mapUnpack -> ( "input", Basics.identity mapUnpack ))
+                 rec.input
+             , Just
+                 ( "loc"
+                 , Json.Encode.list
+                       (\rec0 ->
+                            case rec0 of
+                                Api.Types.Int_Or_String__Int content ->
+                                    Json.Encode.int content
+                            
+                                Api.Types.Int_Or_String__String content ->
+                                    Json.Encode.string content
+                       )
+                       rec.loc
+                 )
+             , Just ( "msg", Json.Encode.string rec.msg )
+             , Just ( "type", Json.Encode.string rec.type_ )
+             ]
+        )
+
+
+decodeAuthSuccess : Json.Decode.Decoder Api.Types.AuthSuccess
+decodeAuthSuccess =
+    Json.Decode.succeed
+        (\token user_info -> { token = token, user_info = user_info })
+        |> OpenApi.Common.jsonDecodeAndMap
+               (Json.Decode.field "token" decodeAuthToken)
+        |> OpenApi.Common.jsonDecodeAndMap
+               (Json.Decode.field "user_info" decodeGenericUserInfo)
+
+
+decodeAuthToken : Json.Decode.Decoder Api.Types.AuthToken
+decodeAuthToken =
+    Json.Decode.succeed
+        (\expires_unixtime hmac_of_rest minted_unixtime owner ->
+             { expires_unixtime = expires_unixtime
+             , hmac_of_rest = hmac_of_rest
+             , minted_unixtime = minted_unixtime
+             , owner = owner
+             }
+        )
+        |> OpenApi.Common.jsonDecodeAndMap
+               (Json.Decode.field "expires_unixtime" Json.Decode.float)
+        |> OpenApi.Common.jsonDecodeAndMap
+               (Json.Decode.field "hmac_of_rest" OpenApi.Common.decodeStringByte
+               )
+        |> OpenApi.Common.jsonDecodeAndMap
+               (Json.Decode.field "minted_unixtime" Json.Decode.float)
+        |> OpenApi.Common.jsonDecodeAndMap
+               (Json.Decode.field "owner" Json.Decode.string)
+
+
+decodeGenericUserInfo : Json.Decode.Decoder Api.Types.GenericUserInfo
+decodeGenericUserInfo =
+    Json.Decode.succeed
+        (\email_address invitations login_type relationships ->
+             { email_address = email_address
+             , invitations = invitations
+             , login_type = login_type
+             , relationships = relationships
+             }
+        )
+        |> OpenApi.Common.jsonDecodeAndMap
+               (Json.Decode.field "email_address" Json.Decode.string)
+        |> OpenApi.Common.jsonDecodeAndMap
+               (Json.Decode.field
+                    "invitations"
+                    (Json.Decode.dict decodeInvitation)
+               )
+        |> OpenApi.Common.jsonDecodeAndMap
+               (Json.Decode.field
+                    "login_type"
+                    (Json.Decode.oneOf
+                         [ Json.Decode.map
+                             OpenApi.Common.Present
+                             decodeLoginTypePassword
+                         , Json.Decode.null (OpenApi.Common.Null)
+                         ]
+                    )
+               )
+        |> OpenApi.Common.jsonDecodeAndMap
+               (Json.Decode.field
+                    "relationships"
+                    (Json.Decode.dict decodeRelationship)
+               )
+
+
+decodeHTTPValidationError : Json.Decode.Decoder Api.Types.HTTPValidationError
+decodeHTTPValidationError =
+    Json.Decode.succeed (\detail -> { detail = detail })
+        |> OpenApi.Common.jsonDecodeAndMap
+               (OpenApi.Common.decodeOptionalField
+                    "detail"
+                    (Json.Decode.list decodeValidationError)
+               )
+
+
+decodeHashedPassword : Json.Decode.Decoder Api.Types.HashedPassword
+decodeHashedPassword =
+    Json.Decode.succeed (\salt scrypt -> { salt = salt, scrypt = scrypt })
+        |> OpenApi.Common.jsonDecodeAndMap
+               (Json.Decode.field "salt" OpenApi.Common.decodeStringByte)
+        |> OpenApi.Common.jsonDecodeAndMap
+               (Json.Decode.field "scrypt" OpenApi.Common.decodeStringByte)
+
+
+decodeInvitation : Json.Decode.Decoder Api.Types.Invitation
+decodeInvitation =
+    Json.Decode.succeed {}
+
+
+decodeLogInUsernameError : Json.Decode.Decoder Api.Types.LogInUsernameError
+decodeLogInUsernameError =
+    Json.Decode.succeed (\catchall -> { catchall = catchall })
+        |> OpenApi.Common.jsonDecodeAndMap
+               (Json.Decode.field "catchall" Json.Decode.string)
+
+
+decodeLogInUsernameRequest : Json.Decode.Decoder Api.Types.LogInUsernameRequest
+decodeLogInUsernameRequest =
+    Json.Decode.succeed
+        (\password username -> { password = password, username = username })
+        |> OpenApi.Common.jsonDecodeAndMap
+               (Json.Decode.field "password" Json.Decode.string)
+        |> OpenApi.Common.jsonDecodeAndMap
+               (Json.Decode.field "username" Json.Decode.string)
+
+
+decodeLogInUsernameResultError :
+    Json.Decode.Decoder Api.Types.LogInUsernameResultError
+decodeLogInUsernameResultError =
+    Json.Decode.succeed
+        (\error log_in_username_result ->
+             { error = error, log_in_username_result = log_in_username_result }
+        )
+        |> OpenApi.Common.jsonDecodeAndMap
+               (Json.Decode.field "error" decodeLogInUsernameError)
+        |> OpenApi.Common.jsonDecodeAndMap
+               (OpenApi.Common.decodeOptionalField
+                    "log_in_username_result"
+                    (Json.Decode.andThen
+                         (\andThenUnpack ->
+                              if andThenUnpack == "error" then
+                                  Json.Decode.succeed andThenUnpack
+                              
+                              else
+                                  Json.Decode.fail
+                                      ("Unexpected value: expected \"error\" got " ++
+                                           Json.Encode.encode
+                                               0
+                                               (Json.Encode.string andThenUnpack
+                                               )
+                                      )
+                         )
+                         Json.Decode.string
+                    )
+               )
+
+
+decodeLogInUsernameResultOk :
+    Json.Decode.Decoder Api.Types.LogInUsernameResultOk
+decodeLogInUsernameResultOk =
+    Json.Decode.succeed
+        (\log_in_username_result ok ->
+             { log_in_username_result = log_in_username_result, ok = ok }
+        )
+        |> OpenApi.Common.jsonDecodeAndMap
+               (OpenApi.Common.decodeOptionalField
+                    "log_in_username_result"
+                    (Json.Decode.andThen
+                         (\andThenUnpack ->
+                              if andThenUnpack == "ok" then
+                                  Json.Decode.succeed andThenUnpack
+                              
+                              else
+                                  Json.Decode.fail
+                                      ("Unexpected value: expected \"ok\" got " ++
+                                           Json.Encode.encode
+                                               0
+                                               (Json.Encode.string andThenUnpack
+                                               )
+                                      )
+                         )
+                         Json.Decode.string
+                    )
+               )
+        |> OpenApi.Common.jsonDecodeAndMap
+               (Json.Decode.field "ok" decodeAuthSuccess)
+
+
+decodeLoginTypePassword : Json.Decode.Decoder Api.Types.LoginTypePassword
+decodeLoginTypePassword =
+    Json.Decode.succeed
+        (\login_password login_type_kind ->
+             { login_password = login_password
+             , login_type_kind = login_type_kind
+             }
+        )
+        |> OpenApi.Common.jsonDecodeAndMap
+               (Json.Decode.field "login_password" decodeHashedPassword)
+        |> OpenApi.Common.jsonDecodeAndMap
+               (OpenApi.Common.decodeOptionalField
+                    "login_type_kind"
+                    (Json.Decode.andThen
+                         (\andThenUnpack ->
+                              if andThenUnpack == "login_password" then
+                                  Json.Decode.succeed andThenUnpack
+                              
+                              else
+                                  Json.Decode.fail
+                                      ("Unexpected value: expected \"login_password\" got " ++
+                                           Json.Encode.encode
+                                               0
+                                               (Json.Encode.string andThenUnpack
+                                               )
+                                      )
+                         )
+                         Json.Decode.string
+                    )
+               )
+
+
+decodeRelationship : Json.Decode.Decoder Api.Types.Relationship
+decodeRelationship =
+    Json.Decode.succeed
+        (\trusted_by_you trusts_you ->
+             { trusted_by_you = trusted_by_you, trusts_you = trusts_you }
+        )
+        |> OpenApi.Common.jsonDecodeAndMap
+               (Json.Decode.field "trusted_by_you" Json.Decode.bool)
+        |> OpenApi.Common.jsonDecodeAndMap
+               (Json.Decode.field "trusts_you" Json.Decode.bool)
+
+
+decodeValidationError : Json.Decode.Decoder Api.Types.ValidationError
+decodeValidationError =
+    Json.Decode.succeed
+        (\ctx input loc msg type_ ->
+             { ctx = ctx, input = input, loc = loc, msg = msg, type_ = type_ }
+        )
+        |> OpenApi.Common.jsonDecodeAndMap
+               (OpenApi.Common.decodeOptionalField
+                    "ctx"
+                    (Json.Decode.succeed {})
+               )
+        |> OpenApi.Common.jsonDecodeAndMap
+               (OpenApi.Common.decodeOptionalField "input" Json.Decode.value)
+        |> OpenApi.Common.jsonDecodeAndMap
+               (Json.Decode.field
+                    "loc"
+                    (Json.Decode.list
+                         (Json.Decode.oneOf
+                              [ Json.Decode.map
+                                  Api.Types.Int_Or_String__Int
+                                  Json.Decode.int
+                              , Json.Decode.map
+                                  Api.Types.Int_Or_String__String
+                                  Json.Decode.string
+                              ]
+                         )
+                    )
+               )
+        |> OpenApi.Common.jsonDecodeAndMap
+               (Json.Decode.field "msg" Json.Decode.string)
+        |> OpenApi.Common.jsonDecodeAndMap
+               (Json.Decode.field "type" Json.Decode.string)

--- a/spike/openapi-elm/elm-check/src/Api/Types.elm
+++ b/spike/openapi-elm/elm-check/src/Api/Types.elm
@@ -1,0 +1,100 @@
+module Api.Types exposing
+    ( AuthSuccess, AuthToken, GenericUserInfo, HTTPValidationError, HashedPassword, Invitation, LogInUsernameError
+    , LogInUsernameRequest, LogInUsernameResultError, LogInUsernameResultOk, LoginTypePassword, Relationship, ValidationError
+    , Int_Or_String(..), LogInUsernameResultError_Or_LogInUsernameResultOk(..)
+    )
+
+{-|
+## Aliases
+
+@docs AuthSuccess, AuthToken, GenericUserInfo, HTTPValidationError, HashedPassword, Invitation
+@docs LogInUsernameError, LogInUsernameRequest, LogInUsernameResultError, LogInUsernameResultOk, LoginTypePassword, Relationship
+@docs ValidationError
+
+## One of
+
+@docs Int_Or_String, LogInUsernameResultError_Or_LogInUsernameResultOk
+-}
+
+
+import Bytes
+import Dict
+import Json.Encode
+import OpenApi.Common
+
+
+type alias AuthSuccess =
+    { token : AuthToken, user_info : GenericUserInfo }
+
+
+type alias AuthToken =
+    { expires_unixtime : Float
+    , hmac_of_rest : Bytes.Bytes
+    , minted_unixtime : Float
+    , owner : String
+    }
+
+
+type alias GenericUserInfo =
+    { email_address : String
+    , invitations : Dict.Dict String Invitation
+    , login_type : OpenApi.Common.Nullable LoginTypePassword
+    , relationships : Dict.Dict String Relationship
+    }
+
+
+type alias HTTPValidationError =
+    { detail : Maybe (List ValidationError) }
+
+
+type alias HashedPassword =
+    { salt : Bytes.Bytes, scrypt : Bytes.Bytes }
+
+
+type alias Invitation =
+    {}
+
+
+type alias LogInUsernameError =
+    { catchall : String }
+
+
+type alias LogInUsernameRequest =
+    { password : String, username : String }
+
+
+type alias LogInUsernameResultError =
+    { error : LogInUsernameError, log_in_username_result : Maybe String }
+
+
+type alias LogInUsernameResultOk =
+    { log_in_username_result : Maybe String, ok : AuthSuccess }
+
+
+type alias LoginTypePassword =
+    { login_password : HashedPassword, login_type_kind : Maybe String }
+
+
+type alias Relationship =
+    { trusted_by_you : Bool, trusts_you : Bool }
+
+
+type alias ValidationError =
+    { ctx : Maybe {}
+    , input : Maybe Json.Encode.Value
+    , loc : List Int_Or_String
+    , msg : String
+    , type_ : String
+    }
+
+
+type Int_Or_String
+    = Int_Or_String__Int Int
+    | Int_Or_String__String String
+
+
+type LogInUsernameResultError_Or_LogInUsernameResultOk
+    = LogInUsernameResultError_Or_LogInUsernameResultOk__LogInUsernameResultError
+        LogInUsernameResultError
+    | LogInUsernameResultError_Or_LogInUsernameResultOk__LogInUsernameResultOk
+        LogInUsernameResultOk

--- a/spike/openapi-elm/elm-check/src/OpenApi/Common.elm
+++ b/spike/openapi-elm/elm-check/src/OpenApi/Common.elm
@@ -1,0 +1,294 @@
+module OpenApi.Common exposing
+    ( encodeStringByte, toParamStringStringByte
+    , decodeStringByte
+    , Nullable(..), Error(..), jsonDecodeAndMap, decodeOptionalField
+    , bytesResolverCustom, expectBytesCustom, stringResolverCustom, expectStringCustom, jsonResolverCustom, expectJsonCustom, base64ResolverCustom
+    , expectBase64Custom
+    )
+
+{-|
+## Encoders
+
+@docs encodeStringByte, toParamStringStringByte
+
+## Decoders
+
+@docs decodeStringByte
+
+## Common
+
+@docs Nullable, Error, jsonDecodeAndMap, decodeOptionalField
+
+## elm/http
+
+@docs bytesResolverCustom, expectBytesCustom, stringResolverCustom, expectStringCustom, jsonResolverCustom, expectJsonCustom
+@docs base64ResolverCustom, expectBase64Custom
+-}
+
+
+import Base64
+import Bytes
+import Bytes.Decode
+import Dict
+import Http
+import Json.Decode
+import Json.Encode
+
+
+encodeStringByte : Bytes.Bytes -> Json.Encode.Value
+encodeStringByte value =
+    Json.Encode.string (Maybe.withDefault "" (Base64.fromBytes value))
+
+
+toParamStringStringByte : Bytes.Bytes -> String
+toParamStringStringByte value =
+    Maybe.withDefault "" (Base64.fromBytes value)
+
+
+decodeStringByte : Json.Decode.Decoder Bytes.Bytes
+decodeStringByte =
+    Json.Decode.andThen
+        (\andThenUnpack ->
+             case Base64.toBytes andThenUnpack of
+                 Nothing ->
+                     Json.Decode.fail "Invalid base64 data"
+             
+                 Just bytes ->
+                     Json.Decode.succeed bytes
+        )
+        Json.Decode.string
+
+
+type Nullable value
+    = Null
+    | Present value
+
+
+type Error err body
+    = BadUrl String
+    | Timeout
+    | NetworkError
+    | KnownBadStatus Int err
+    | UnknownBadStatus Http.Metadata body
+    | BadErrorBody Http.Metadata body
+    | BadBody Http.Metadata body
+
+
+{-| Chain JSON decoders, when `Json.Decode.map8` isn't enough. -}
+jsonDecodeAndMap :
+    Json.Decode.Decoder a
+    -> Json.Decode.Decoder (a -> value)
+    -> Json.Decode.Decoder value
+jsonDecodeAndMap dx df =
+    Json.Decode.map2 (|>) dx df
+
+
+{-| Decode an optional field
+
+    decodeString (decodeOptionalField "x" int) "{ "x": 3 }"
+    --> Ok (Just 3)
+
+    decodeString (decodeOptionalField "x" int) "{ "x": true }"
+    --> Err ...
+
+    decodeString (decodeOptionalField "x" int) "{ "y": 4 }"
+    --> Ok Nothing
+-}
+decodeOptionalField :
+    String -> Json.Decode.Decoder t -> Json.Decode.Decoder (Maybe t)
+decodeOptionalField key fieldDecoder =
+    Json.Decode.andThen
+        (\andThenUnpack ->
+             if andThenUnpack then
+                 Json.Decode.field
+                     key
+                     (Json.Decode.oneOf
+                          [ Json.Decode.map Just fieldDecoder
+                          , Json.Decode.null Nothing
+                          ]
+                     )
+             
+             else
+                 Json.Decode.succeed Nothing
+        )
+        (Json.Decode.oneOf
+             [ Json.Decode.map
+                 (\_ -> True)
+                 (Json.Decode.field key Json.Decode.value)
+             , Json.Decode.succeed False
+             ]
+        )
+
+
+responseToResult :
+    Dict.Dict String (Json.Decode.Decoder err)
+    -> (body -> String)
+    -> (Http.Metadata -> body -> Result (Error err body) value)
+    -> Http.Response body
+    -> Result (Error err body) value
+responseToResult errorDecoders bodyToString onSuccess response =
+    case response of
+        Http.BadUrl_ arg_0 ->
+            Result.Err (BadUrl arg_0)
+    
+        Http.Timeout_ ->
+            Result.Err (Timeout)
+    
+        Http.NetworkError_ ->
+            Result.Err (NetworkError)
+    
+        Http.BadStatus_ httpMetadata body ->
+            case Dict.get (String.fromInt httpMetadata.statusCode) errorDecoders
+            of
+                Nothing ->
+                    Result.Err (UnknownBadStatus httpMetadata body)
+            
+                Just err ->
+                    case Json.Decode.decodeString err (bodyToString body) of
+                        Ok res ->
+                            Result.Err
+                                (KnownBadStatus httpMetadata.statusCode res)
+                    
+                        Err _ ->
+                            Result.Err (BadErrorBody httpMetadata body)
+    
+        Http.GoodStatus_ httpMetadata body ->
+            onSuccess httpMetadata body
+
+
+bytesResolverCustom :
+    Dict.Dict String (Json.Decode.Decoder err)
+    -> Http.Resolver (Error err Bytes.Bytes) Bytes.Bytes
+bytesResolverCustom errorDecoders =
+    Http.bytesResolver
+        (responseToResult
+             errorDecoders
+             (\body ->
+                  Maybe.withDefault
+                      ""
+                      (Bytes.Decode.decode
+                           (Bytes.Decode.string (Bytes.width body))
+                           body
+                      )
+             )
+             (\metadata body -> Result.Ok body)
+        )
+
+
+expectBytesCustom :
+    Dict.Dict String (Json.Decode.Decoder err)
+    -> (Result (Error err Bytes.Bytes) Bytes.Bytes -> msg)
+    -> Http.Expect msg
+expectBytesCustom errorDecoders toMsg =
+    Http.expectBytesResponse
+        toMsg
+        (responseToResult
+             errorDecoders
+             (\body ->
+                  Maybe.withDefault
+                      ""
+                      (Bytes.Decode.decode
+                           (Bytes.Decode.string (Bytes.width body))
+                           body
+                      )
+             )
+             (\metadata body -> Result.Ok body)
+        )
+
+
+stringResolverCustom :
+    Dict.Dict String (Json.Decode.Decoder err)
+    -> Http.Resolver (Error err String) String
+stringResolverCustom errorDecoders =
+    Http.stringResolver
+        (responseToResult
+             errorDecoders
+             Basics.identity
+             (\metadata body -> Result.Ok body)
+        )
+
+
+expectStringCustom :
+    Dict.Dict String (Json.Decode.Decoder err)
+    -> (Result (Error err String) String -> msg)
+    -> Http.Expect msg
+expectStringCustom errorDecoders toMsg =
+    Http.expectStringResponse
+        toMsg
+        (responseToResult
+             errorDecoders
+             Basics.identity
+             (\metadata body -> Result.Ok body)
+        )
+
+
+jsonResolverCustom :
+    Dict.Dict String (Json.Decode.Decoder err)
+    -> Json.Decode.Decoder success
+    -> Http.Resolver (Error err String) success
+jsonResolverCustom errorDecoders successDecoder =
+    Http.stringResolver
+        (responseToResult
+             errorDecoders
+             Basics.identity
+             (\metadata body ->
+                  case Json.Decode.decodeString successDecoder body of
+                      Ok res ->
+                          Result.Ok res
+                  
+                      Err _ ->
+                          Result.Err (BadBody metadata body)
+             )
+        )
+
+
+expectJsonCustom :
+    Dict.Dict String (Json.Decode.Decoder err)
+    -> Json.Decode.Decoder success
+    -> (Result (Error err String) success -> msg)
+    -> Http.Expect msg
+expectJsonCustom errorDecoders successDecoder toMsg =
+    Http.expectStringResponse
+        toMsg
+        (responseToResult
+             errorDecoders
+             Basics.identity
+             (\metadata body ->
+                  case Json.Decode.decodeString successDecoder body of
+                      Ok res ->
+                          Result.Ok res
+                  
+                      Err _ ->
+                          Result.Err (BadBody metadata body)
+             )
+        )
+
+
+base64ResolverCustom :
+    Dict.Dict String (Json.Decode.Decoder err)
+    -> Http.Resolver (Error err String) Bytes.Bytes
+base64ResolverCustom errorDecoders =
+    Http.stringResolver
+        (responseToResult
+             errorDecoders
+             Basics.identity
+             (\metadata body ->
+                  Result.fromMaybe (BadBody metadata body) (Base64.toBytes body)
+             )
+        )
+
+
+expectBase64Custom :
+    Dict.Dict String (Json.Decode.Decoder err)
+    -> (Result (Error err String) Bytes.Bytes -> msg)
+    -> Http.Expect msg
+expectBase64Custom errorDecoders toMsg =
+    Http.expectStringResponse
+        toMsg
+        (responseToResult
+             errorDecoders
+             Basics.identity
+             (\metadata body ->
+                  Result.fromMaybe (BadBody metadata body) (Base64.toBytes body)
+             )
+        )

--- a/spike/openapi-elm/elm-check/tests/RoundTripTest.elm
+++ b/spike/openapi-elm/elm-check/tests/RoundTripTest.elm
@@ -1,0 +1,106 @@
+module RoundTripTest exposing (suite)
+
+{-| Feeds the generated Elm decoders the *actual* JSON emitted by the FastAPI
+app in ../app.py (captured verbatim in ../sample_ok.json and ../sample_err.json).
+
+The point of the spike: can Elm consume a Pydantic-shaped `oneOf` response and
+`case` on it like it does today with protobuf's `oneof`?
+-}
+
+import Api.Json
+import Api.Types exposing (LogInUsernameResultError_Or_LogInUsernameResultOk(..))
+import Bytes
+import Dict
+import Expect
+import Json.Decode as JD
+import Test exposing (Test, describe, test)
+
+
+{-| Verbatim from `curl`ing the FastAPI app -- see ../sample_ok.json -}
+sampleOk : String
+sampleOk =
+    """
+    {
+      "log_in_username_result": "ok",
+      "ok": {
+        "token": {
+          "hmac_of_rest": "AAH+/4A=",
+          "owner": "spike",
+          "minted_unixtime": 1600000000.0,
+          "expires_unixtime": 1600086400.0
+        },
+        "user_info": {
+          "email_address": "spike@example.com",
+          "invitations": { "some-nonce": {} },
+          "relationships": {
+            "alice": { "trusts_you": true, "trusted_by_you": false }
+          },
+          "login_type": {
+            "login_type_kind": "login_password",
+            "login_password": { "salt": "3q2+7w==", "scrypt": "AQID" }
+          }
+        }
+      }
+    }
+    """
+
+
+{-| Verbatim -- see ../sample_err.json -}
+sampleErr : String
+sampleErr =
+    """
+    { "log_in_username_result": "error", "error": { "catchall": "bad password" } }
+    """
+
+
+{-| The union decoder as assembled by the generator in Api/Api.elm. -}
+responseDecoder : JD.Decoder LogInUsernameResultError_Or_LogInUsernameResultOk
+responseDecoder =
+    JD.oneOf
+        [ JD.map LogInUsernameResultError_Or_LogInUsernameResultOk__LogInUsernameResultError
+            Api.Json.decodeLogInUsernameResultError
+        , JD.map LogInUsernameResultError_Or_LogInUsernameResultOk__LogInUsernameResultOk
+            Api.Json.decodeLogInUsernameResultOk
+        ]
+
+
+suite : Test
+suite =
+    describe "generated decoders vs. real FastAPI output"
+        [ test "Ok arm dispatches to the Ok constructor" <|
+            \_ ->
+                case JD.decodeString responseDecoder sampleOk of
+                    Ok (LogInUsernameResultError_Or_LogInUsernameResultOk__LogInUsernameResultOk r) ->
+                        Expect.equal "spike" r.ok.token.owner
+
+                    other ->
+                        Expect.fail ("expected Ok arm, got: " ++ Debug.toString other)
+        , test "Error arm dispatches to the Error constructor" <|
+            \_ ->
+                case JD.decodeString responseDecoder sampleErr of
+                    Ok (LogInUsernameResultError_Or_LogInUsernameResultOk__LogInUsernameResultError r) ->
+                        Expect.equal "bad password" r.error.catchall
+
+                    other ->
+                        Expect.fail ("expected Error arm, got: " ++ Debug.toString other)
+        , test "base64 bytes decode to real Bytes of the right width" <|
+            \_ ->
+                case JD.decodeString responseDecoder sampleOk of
+                    Ok (LogInUsernameResultError_Or_LogInUsernameResultOk__LogInUsernameResultOk r) ->
+                        -- b"\x00\x01\xfe\xff\x80" is 5 bytes
+                        Expect.equal 5 (Bytes.width r.ok.token.hmac_of_rest)
+
+                    other ->
+                        Expect.fail ("expected Ok arm, got: " ++ Debug.toString other)
+        , test "map<string, Relationship> survives" <|
+            \_ ->
+                case JD.decodeString responseDecoder sampleOk of
+                    Ok (LogInUsernameResultError_Or_LogInUsernameResultOk__LogInUsernameResultOk r) ->
+                        r.ok.user_info.relationships
+                            |> Dict.get "alice"
+                            |> Maybe.map .trusts_you
+                            |> Expect.equal (Just True)
+
+                    other ->
+                        Expect.fail ("expected Ok arm, got: " ++ Debug.toString other)
+        ]

--- a/spike/openapi-elm/gen_openapi.py
+++ b/spike/openapi-elm/gen_openapi.py
@@ -1,0 +1,8 @@
+import json
+from pathlib import Path
+
+from app import app
+
+schema = app.openapi()
+Path(__file__).parent.joinpath("openapi.json").write_text(json.dumps(schema, indent=2) + "\n")
+print("wrote openapi.json")

--- a/spike/openapi-elm/models.py
+++ b/spike/openapi-elm/models.py
@@ -1,0 +1,143 @@
+"""Pydantic translation of the LogInUsername slice of protobuf/mvp.proto.
+
+This slice was chosen because it transitively exercises every proto feature that
+the rest of the API depends on:
+
+  - `oneof log_in_username_result` -> the Ok/Error result union that EVERY
+    endpoint in mvp.proto is built on. This is the crux of the spike.
+  - nested `message Error` inside the response
+  - `bytes` fields (AuthToken.hmac_of_rest, HashedPassword.salt/.scrypt)
+  - `map<string, X>` (GenericUserInfo.invitations, .relationships)
+  - a second, single-armed `oneof login_type`
+  - an empty message (GenericUserInfo.Invitation)
+
+If the generated Elm is good for this slice, it will be good for the whole API.
+"""
+
+import base64
+from typing import Annotated, Any, Dict, Literal, Union
+
+from pydantic import BaseModel, BeforeValidator, Field, PlainSerializer, WithJsonSchema
+
+
+# --- bytes handling ----------------------------------------------------------
+#
+# DO NOT use pydantic's `Base64Bytes` here. Its semantics are inverted from what
+# you want: it base64-DECODES on validation, so constructing a model with raw
+# bytes from Python silently mangles them --
+#
+#     class M(BaseModel): b: Base64Bytes
+#     M(b=b'\xde\xad\xbe\xef').b  ==  b''      # no error raised!
+#
+# ...which is exactly what core.new_hashed_password() does with
+# secrets.token_bytes(4). It corrupts to empty for some inputs and raises for
+# others, depending on whether the raw bytes happen to be valid base64.
+#
+# Instead: keep `bytes` as the Python-side type and base64 only at the JSON
+# boundary. `format: byte` (not `base64`) is the format elm-open-api recognises.
+
+def _decode_bytes(v: Any) -> Any:
+    if isinstance(v, str):      # came off the wire as base64
+        return base64.b64decode(v, validate=True)
+    return v                    # already raw bytes from Python
+
+ProtoBytes = Annotated[
+    bytes,
+    BeforeValidator(_decode_bytes),
+    PlainSerializer(
+        lambda b: base64.b64encode(b).decode("ascii"),
+        return_type=str,
+        when_used="json",
+    ),
+    WithJsonSchema({"type": "string", "format": "byte"}),
+]
+
+
+# --- leaves ------------------------------------------------------------------
+
+class HashedPassword(BaseModel):
+    # proto: bytes salt = 1; bytes scrypt = 2;
+    salt: ProtoBytes
+    scrypt: ProtoBytes
+
+
+class AuthToken(BaseModel):
+    # proto: bytes hmac_of_rest = 1; string owner = 7;
+    #        double minted_unixtime = 5; double expires_unixtime = 6;
+    hmac_of_rest: ProtoBytes
+    owner: str
+    minted_unixtime: float
+    expires_unixtime: float
+
+
+class Relationship(BaseModel):
+    # proto: bool trusts_you = 1; bool trusted_by_you = 2;
+    trusts_you: bool
+    trusted_by_you: bool
+
+
+class Invitation(BaseModel):
+    # proto: message Invitation {}  -- deliberately empty
+    pass
+
+
+# --- login_type oneof --------------------------------------------------------
+
+class LoginTypePassword(BaseModel):
+    login_type_kind: Literal["login_password"] = "login_password"
+    login_password: HashedPassword
+
+
+LoginType = Annotated[
+    Union[LoginTypePassword],
+    Field(discriminator="login_type_kind"),
+]
+
+
+class GenericUserInfo(BaseModel):
+    # NOTE: these are deliberately *required* (no defaults) even though a default
+    # of {} would be more natural in Python. A field with a default is omitted
+    # from OpenAPI's `required`, and the Elm generator then wraps it in a Maybe:
+    #     invitations : Maybe (Dict.Dict String Invitation)   -- default present
+    #     invitations : Dict.Dict String Invitation           -- required
+    # Same for login_type: required-but-nullable gives `Nullable LoginTypePassword`,
+    # whereas defaulted-and-nullable gives a `Maybe (Nullable ...)` double-option.
+    # Requiring them costs the server an explicit `invitations={}` and buys the
+    # Elm side a pile of removed Maybe-unwrapping.
+    email_address: str
+    invitations: Dict[str, Invitation]
+    relationships: Dict[str, Relationship]
+    login_type: LoginType | None
+
+
+class AuthSuccess(BaseModel):
+    token: AuthToken
+    user_info: GenericUserInfo
+
+
+# --- the endpoint ------------------------------------------------------------
+
+class LogInUsernameRequest(BaseModel):
+    username: str
+    password: str
+
+
+class LogInUsernameError(BaseModel):
+    # proto: message Error { string catchall = 1; }
+    catchall: str
+
+
+class LogInUsernameResultOk(BaseModel):
+    log_in_username_result: Literal["ok"] = "ok"
+    ok: AuthSuccess
+
+
+class LogInUsernameResultError(BaseModel):
+    log_in_username_result: Literal["error"] = "error"
+    error: LogInUsernameError
+
+
+LogInUsernameResponse = Annotated[
+    Union[LogInUsernameResultOk, LogInUsernameResultError],
+    Field(discriminator="log_in_username_result"),
+]

--- a/spike/openapi-elm/openapi.json
+++ b/spike/openapi-elm/openapi.json
@@ -1,0 +1,343 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "biatob (LogInUsername spike)",
+    "version": "0.0.1"
+  },
+  "paths": {
+    "/api/LogInUsername": {
+      "post": {
+        "summary": "Log In Username",
+        "operationId": "logInUsername",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/LogInUsernameRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/LogInUsernameResultOk"
+                    },
+                    {
+                      "$ref": "#/components/schemas/LogInUsernameResultError"
+                    }
+                  ],
+                  "title": "Response Loginusername",
+                  "discriminator": {
+                    "propertyName": "log_in_username_result",
+                    "mapping": {
+                      "ok": "#/components/schemas/LogInUsernameResultOk",
+                      "error": "#/components/schemas/LogInUsernameResultError"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "AuthSuccess": {
+        "properties": {
+          "token": {
+            "$ref": "#/components/schemas/AuthToken"
+          },
+          "user_info": {
+            "$ref": "#/components/schemas/GenericUserInfo"
+          }
+        },
+        "type": "object",
+        "required": [
+          "token",
+          "user_info"
+        ],
+        "title": "AuthSuccess"
+      },
+      "AuthToken": {
+        "properties": {
+          "hmac_of_rest": {
+            "type": "string",
+            "format": "byte",
+            "title": "Hmac Of Rest"
+          },
+          "owner": {
+            "type": "string",
+            "title": "Owner"
+          },
+          "minted_unixtime": {
+            "type": "number",
+            "title": "Minted Unixtime"
+          },
+          "expires_unixtime": {
+            "type": "number",
+            "title": "Expires Unixtime"
+          }
+        },
+        "type": "object",
+        "required": [
+          "hmac_of_rest",
+          "owner",
+          "minted_unixtime",
+          "expires_unixtime"
+        ],
+        "title": "AuthToken"
+      },
+      "GenericUserInfo": {
+        "properties": {
+          "email_address": {
+            "type": "string",
+            "title": "Email Address"
+          },
+          "invitations": {
+            "additionalProperties": {
+              "$ref": "#/components/schemas/Invitation"
+            },
+            "type": "object",
+            "title": "Invitations"
+          },
+          "relationships": {
+            "additionalProperties": {
+              "$ref": "#/components/schemas/Relationship"
+            },
+            "type": "object",
+            "title": "Relationships"
+          },
+          "login_type": {
+            "anyOf": [
+              {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/LoginTypePassword"
+                  }
+                ],
+                "discriminator": {
+                  "propertyName": "login_type_kind",
+                  "mapping": {
+                    "login_password": "#/components/schemas/LoginTypePassword"
+                  }
+                }
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Login Type"
+          }
+        },
+        "type": "object",
+        "required": [
+          "email_address",
+          "invitations",
+          "relationships",
+          "login_type"
+        ],
+        "title": "GenericUserInfo"
+      },
+      "HTTPValidationError": {
+        "properties": {
+          "detail": {
+            "items": {
+              "$ref": "#/components/schemas/ValidationError"
+            },
+            "type": "array",
+            "title": "Detail"
+          }
+        },
+        "type": "object",
+        "title": "HTTPValidationError"
+      },
+      "HashedPassword": {
+        "properties": {
+          "salt": {
+            "type": "string",
+            "format": "byte",
+            "title": "Salt"
+          },
+          "scrypt": {
+            "type": "string",
+            "format": "byte",
+            "title": "Scrypt"
+          }
+        },
+        "type": "object",
+        "required": [
+          "salt",
+          "scrypt"
+        ],
+        "title": "HashedPassword"
+      },
+      "Invitation": {
+        "properties": {},
+        "type": "object",
+        "title": "Invitation"
+      },
+      "LogInUsernameError": {
+        "properties": {
+          "catchall": {
+            "type": "string",
+            "title": "Catchall"
+          }
+        },
+        "type": "object",
+        "required": [
+          "catchall"
+        ],
+        "title": "LogInUsernameError"
+      },
+      "LogInUsernameRequest": {
+        "properties": {
+          "username": {
+            "type": "string",
+            "title": "Username"
+          },
+          "password": {
+            "type": "string",
+            "title": "Password"
+          }
+        },
+        "type": "object",
+        "required": [
+          "username",
+          "password"
+        ],
+        "title": "LogInUsernameRequest"
+      },
+      "LogInUsernameResultError": {
+        "properties": {
+          "log_in_username_result": {
+            "type": "string",
+            "const": "error",
+            "title": "Log In Username Result",
+            "default": "error"
+          },
+          "error": {
+            "$ref": "#/components/schemas/LogInUsernameError"
+          }
+        },
+        "type": "object",
+        "required": [
+          "error"
+        ],
+        "title": "LogInUsernameResultError"
+      },
+      "LogInUsernameResultOk": {
+        "properties": {
+          "log_in_username_result": {
+            "type": "string",
+            "const": "ok",
+            "title": "Log In Username Result",
+            "default": "ok"
+          },
+          "ok": {
+            "$ref": "#/components/schemas/AuthSuccess"
+          }
+        },
+        "type": "object",
+        "required": [
+          "ok"
+        ],
+        "title": "LogInUsernameResultOk"
+      },
+      "LoginTypePassword": {
+        "properties": {
+          "login_type_kind": {
+            "type": "string",
+            "const": "login_password",
+            "title": "Login Type Kind",
+            "default": "login_password"
+          },
+          "login_password": {
+            "$ref": "#/components/schemas/HashedPassword"
+          }
+        },
+        "type": "object",
+        "required": [
+          "login_password"
+        ],
+        "title": "LoginTypePassword"
+      },
+      "Relationship": {
+        "properties": {
+          "trusts_you": {
+            "type": "boolean",
+            "title": "Trusts You"
+          },
+          "trusted_by_you": {
+            "type": "boolean",
+            "title": "Trusted By You"
+          }
+        },
+        "type": "object",
+        "required": [
+          "trusts_you",
+          "trusted_by_you"
+        ],
+        "title": "Relationship"
+      },
+      "ValidationError": {
+        "properties": {
+          "loc": {
+            "items": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "integer"
+                }
+              ]
+            },
+            "type": "array",
+            "title": "Location"
+          },
+          "msg": {
+            "type": "string",
+            "title": "Message"
+          },
+          "type": {
+            "type": "string",
+            "title": "Error Type"
+          },
+          "input": {
+            "title": "Input"
+          },
+          "ctx": {
+            "type": "object",
+            "title": "Context"
+          }
+        },
+        "type": "object",
+        "required": [
+          "loc",
+          "msg",
+          "type"
+        ],
+        "title": "ValidationError"
+      }
+    }
+  }
+}

--- a/spike/openapi-elm/run.sh
+++ b/spike/openapi-elm/run.sh
@@ -1,0 +1,41 @@
+#! /bin/bash
+# Reproduces the spike end-to-end. Needs python3 and npx (network access for
+# pip/npm). Nothing here is wired into the real build; this dir is throwaway.
+set -euo pipefail
+cd "$(dirname "$0")"
+
+WORK="${WORK:-$(mktemp -d)}"
+echo "scratch dir: $WORK"
+
+# 1. Pydantic models -> OpenAPI schema
+python3 -m venv "$WORK/venv"
+"$WORK/venv/bin/pip" install -q pydantic fastapi httpx
+"$WORK/venv/bin/python" gen_openapi.py
+
+# 2. Real FastAPI responses -> sample_*.json (what Elm must decode)
+"$WORK/venv/bin/python" - <<'PY'
+from fastapi.testclient import TestClient
+from app import app
+import json, warnings; warnings.filterwarnings("ignore")
+c = TestClient(app)
+for name, pw in [("sample_ok", "hunter2"), ("sample_err", "wrong")]:
+    r = c.post("/api/LogInUsername", json={"username": "spike", "password": pw}).json()
+    open(f"{name}.json", "w").write(json.dumps(r, indent=2) + "\n")
+PY
+
+# 3. OpenAPI schema -> Elm
+mkdir -p "$WORK/gen" && cd "$WORK/gen"
+npm init -y >/dev/null 2>&1
+npm install --no-fund --no-audit elm@0.19.1-6 elm-test@0.19.1-revision12 elm-open-api >/dev/null 2>&1
+npm approve-scripts --allow-scripts-pending >/dev/null 2>&1 || true
+npm rebuild elm >/dev/null 2>&1
+cd - >/dev/null
+cp openapi.json "$WORK/gen/"
+(cd "$WORK/gen" && ./node_modules/.bin/elm-open-api openapi.json --output-dir generated --module-name Api)
+rm -rf elm-check/src/Api elm-check/src/OpenApi
+cp -r "$WORK/gen/generated/." elm-check/src/
+
+# 4. Compile the generated Elm and decode the real JSON from step 2
+cd elm-check
+PATH="$WORK/gen/node_modules/.bin:$PATH" ELM_HOME="$WORK/elm-home" \
+  elm-test --compiler "$WORK/gen/node_modules/.bin/elm"

--- a/spike/openapi-elm/sample_err.json
+++ b/spike/openapi-elm/sample_err.json
@@ -1,0 +1,6 @@
+{
+  "log_in_username_result": "error",
+  "error": {
+    "catchall": "bad password"
+  }
+}

--- a/spike/openapi-elm/sample_ok.json
+++ b/spike/openapi-elm/sample_ok.json
@@ -1,0 +1,30 @@
+{
+  "log_in_username_result": "ok",
+  "ok": {
+    "token": {
+      "hmac_of_rest": "AAH+/4A=",
+      "owner": "spike",
+      "minted_unixtime": 1600000000.0,
+      "expires_unixtime": 1600086400.0
+    },
+    "user_info": {
+      "email_address": "spike@example.com",
+      "invitations": {
+        "some-nonce": {}
+      },
+      "relationships": {
+        "alice": {
+          "trusts_you": true,
+          "trusted_by_you": false
+        }
+      },
+      "login_type": {
+        "login_type_kind": "login_password",
+        "login_password": {
+          "salt": "3q2+7w==",
+          "scrypt": "AQID"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
**Throwaway spike — not for merge as-is.** Nothing here is wired into `dodo.py` or the build; `spike/` should be deleted once the decision is acted on. Opened as a PR so the findings and the generated output are reviewable in a diff.

## The question

Before doing any of the Protobuf → Pydantic/FastAPI/OpenAPI migration, one thing decides whether it's viable: **every response in `mvp.proto` is a `oneof` Ok/Error result, and `oneof` is what OpenAPI generators historically handle worst.** If the generated Elm can't express that as a real custom type, the migration is a downgrade and shouldn't happen.

## Verdict: viable

The `oneof` comes out as a real Elm custom type you can `case` on. Dispatch is genuinely discriminated — the generator emits `Json.Decode.oneOf [try Error, try Ok]`, which looks alarming, but each arm independently validates its own discriminator literal, so it doesn't rely on the arms happening to have disjoint fields.

It actually **beats `protoc-gen-elm` on two points**:

- Today: `{ logInUsernameResult : Maybe LogInUsernameResult }`. That `Maybe` is why all 18 `simplify*Response` helpers in `elm/src/API.elm` carry a dead `Nothing -> Err "neither Ok nor Error in protobuf"` arm. Under OpenAPI the response *is* the union — impossible state gone, 18 dead arms delete themselves.
- Today: `Dict String (Maybe GenericUserInfoInvitation)` — a pointless `Maybe` inside the dict. Gone.

Cost: constructor names are ugly (`LogInUsernameResultError_Or_LogInUsernameResultOk__LogInUsernameResultOk`) and a `RootModel` only fixes the *type* name, not the constructors. Mitigation is a thin adapter — which is what `API.elm`'s `simplify*` layer already is.

## How it was tested

The `LogInUsername` slice, chosen because it transitively covers `oneof`, nested `Error`, `bytes`, `map<string,X>`, a second `oneof`, and an empty message.

Genuinely end-to-end, not schema inspection: `app.py` is a real FastAPI app, its real HTTP responses are captured verbatim into `sample_*.json`, and `RoundTripTest.elm` feeds exactly those bytes to the generated decoders, compiled with **elm 0.19.1** (the version the repo pins). **4/4 passing**, reproducible via `./run.sh` (verified from clean).

Generator is [`elm-open-api`](https://github.com/wolfadex/elm-open-api), *not* `openapi-generator`'s dated Elm target.

## ⚠️ The most valuable finding is a Phase 1 landmine, not an Elm one

**`pydantic.Base64Bytes` silently corrupts data — don't use it.** Its semantics are inverted (it base64-*decodes* on validation):

```python
class M(BaseModel): b: Base64Bytes
M(b=b'\xde\xad\xbe\xef').b   # == b''  -- no error raised
M(b=b'abc!')                 # ValidationError -- inconsistent!
```

Whether you get silent corruption or a loud error depends on whether your random bytes happen to be valid base64. **`core.new_hashed_password()` does exactly this with `secrets.token_bytes(4)`** — a naive port would silently store empty salts for a fraction of users, and no existing test would catch it. The working pattern is `ProtoBytes` in `models.py`.

This bites the moment `HashedPassword`/`AuthToken` become Pydantic models — long before any Elm is regenerated. Whoever does Phase 1 should read finding #1 in `FINDINGS.md` first.

## Other findings

All verified, with fixes applied in `models.py`:

- Use `format: byte`, not `format: base64` — the latter isn't recognised and degrades the field to `String`; the former gets real `Bytes.Bytes`, matching today's protobuf types. Needs `danfishgold/base64-bytes`, which the repo **already** depends on.
- Make wire fields required, or defaults become `Maybe`s (and defaulted-nullable becomes a `Maybe (Nullable ...)` double-option).
- `ConfigDict(alias_generator=to_camel, populate_by_name=True)` emits camelCase JSON while keeping snake_case Python — so today's Elm field names survive and we avoid a rename across all 5,253 lines of Elm.
- Set `operation_id` explicitly, or you get `logInUsernameApiLogInUsernamePost`.

Full detail in `spike/openapi-elm/FINDINGS.md`.

## Not covered

Recursive `ResolutionEvent.prior_revision` (worth a follow-up probe), the localStorage form state (`CreatePrediction.elm:290`), the SSR bootstrap path (`web_server.pb_b64` → Elm flags), and token/cookie signing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
