### PR TITLE
Migrate the auth session cookie off protobuf to a sealed Pydantic token (phase 2a)

### DIFF
--- a/server/api_server.py
+++ b/server/api_server.py
@@ -6,7 +6,7 @@ from aiohttp import web
 from google.protobuf.message import Message
 import structlog
 
-from .core import ApiError, Servicer, TokenMint
+from .core import ApiError, Servicer, TokenMint, Username
 from .http_glue import HttpTokenGlue
 from .protobuf import mvp_pb2
 
@@ -71,13 +71,13 @@ class ApiServer:
     async def RegisterUsername(self, http_req: web.Request) -> web.Response:
         auth_success = self._servicer.RegisterUsername(actor=self._token_glue.get_authorizing_user(http_req), request=await parse_proto(http_req, mvp_pb2.RegisterUsernameRequest))
         http_resp = proto_response(auth_success)
-        self._token_glue.set_cookie(auth_success.token, http_resp)
+        self._token_glue.set_cookie_for_owner(Username(auth_success.token.owner), http_resp)
         return http_resp
     @translates_api_errors
     async def LogInUsername(self, http_req: web.Request) -> web.Response:
         auth_success = self._servicer.LogInUsername(actor=self._token_glue.get_authorizing_user(http_req), request=await parse_proto(http_req, mvp_pb2.LogInUsernameRequest))
         http_resp = proto_response(auth_success)
-        self._token_glue.set_cookie(auth_success.token, http_resp)
+        self._token_glue.set_cookie_for_owner(Username(auth_success.token.owner), http_resp)
         return http_resp
     @translates_api_errors
     async def CreatePrediction(self, http_req: web.Request) -> web.Response:

--- a/server/core.py
+++ b/server/core.py
@@ -1,5 +1,4 @@
 import abc
-import copy
 import datetime
 import hashlib
 import hmac
@@ -11,6 +10,7 @@ from typing import overload, Optional, Container, NewType, Callable
 from aiohttp import web
 from google.protobuf.message import Message
 
+from . import tokens
 from .protobuf import mvp_pb2
 
 PredictionId = NewType('PredictionId', str)
@@ -128,8 +128,8 @@ class InternalError(ApiError):
 @overload
 def token_owner(token: None) -> None: pass
 @overload
-def token_owner(token: mvp_pb2.AuthToken) -> AuthorizingUsername: pass
-def token_owner(token: Optional[mvp_pb2.AuthToken]) -> Optional[AuthorizingUsername]:
+def token_owner(token: tokens.AuthToken) -> AuthorizingUsername: pass
+def token_owner(token: Optional[tokens.AuthToken]) -> Optional[AuthorizingUsername]:
     return None if (token is None) else AuthorizingUsername(Username(token.owner))
 
 
@@ -276,6 +276,9 @@ class Servicer(abc.ABC):
         """Raises NoSuchInvitationError."""
 
 
+AUTH_TOKEN_TTL_SECONDS = 60 * 60 * 24 * 365
+
+
 class TokenMint:
 
     def __init__(self, secret_key: bytes, clock: Callable[[], datetime.datetime] = datetime.datetime.now) -> None:
@@ -285,39 +288,32 @@ class TokenMint:
     def _signature(self, message: Message) -> bytes:
         return hmac.digest(key=self._secret_key, msg=message.SerializeToString(), digest='sha256')
 
-    def _compute_token_hmac(self, token: mvp_pb2.AuthToken) -> bytes:
-        scratchpad = copy.copy(token)
-        scratchpad.hmac_of_rest = b''
-        return self._signature(scratchpad)
+    # --- auth tokens: sealed Pydantic JSON ---
 
-    def _sign_token(self, token: mvp_pb2.AuthToken) -> None:
-        token.hmac_of_rest = self._compute_token_hmac(token=token)
-
-    def mint_token(self, owner: Username, ttl_seconds: int) -> mvp_pb2.AuthToken:
+    def mint_token(self, owner: Username, ttl_seconds: int = AUTH_TOKEN_TTL_SECONDS) -> tokens.AuthToken:
         now = int(self._clock().timestamp())
-        token = mvp_pb2.AuthToken(
+        return tokens.AuthToken(
             owner=owner,
             minted_unixtime=now,
             expires_unixtime=now + ttl_seconds,
         )
-        self._sign_token(token=token)
-        return token
 
-    def check_token(self, token: Optional[mvp_pb2.AuthToken]) -> Optional[AuthorizingUsername]:
+    def seal_token(self, token: tokens.AuthToken) -> str:
+        return tokens.seal(self._secret_key, token)
+
+    def unseal_token(self, sealed: str) -> Optional[tokens.AuthToken]:
+        return tokens.unseal(self._secret_key, sealed, tokens.AuthToken)
+
+    def check_token(self, token: Optional[tokens.AuthToken]) -> Optional[AuthorizingUsername]:
+        # The signature is checked by unseal_token; this checks the time window.
         if token is None:
             return None
         now = int(self._clock().timestamp())
         if not (token.minted_unixtime <= now < token.expires_unixtime):
             return None
-
-        alleged_hmac = token.hmac_of_rest
-        true_hmac = self._compute_token_hmac(token)
-        if not hmac.compare_digest(alleged_hmac, true_hmac):
-            return None
-
         return AuthorizingUsername(Username(token.owner))
 
-    def revoke_token(self, token: mvp_pb2.AuthToken) -> None:
+    def revoke_token(self, token: tokens.AuthToken) -> None:
         pass  # TODO
 
     def sign_proof_of_email(self, email_address: str) -> mvp_pb2.ProofOfEmail:

--- a/server/http_glue.py
+++ b/server/http_glue.py
@@ -1,20 +1,12 @@
-import base64
 from typing import Optional
 
 from aiohttp import web
 import structlog
 
 from .core import AuthorizingUsername, TokenMint, ForgottenTokenError, Username
-from .protobuf import mvp_pb2
+from .tokens import AuthToken
 
 logger = structlog.get_logger()
-
-def _encode_token_for_cookie(token: mvp_pb2.AuthToken) -> str:
-    return base64.b64encode(token.SerializeToString()).decode('ascii')
-def _decode_token_from_cookie(cookie: str) -> mvp_pb2.AuthToken:
-    res = mvp_pb2.AuthToken()
-    res.ParseFromString(base64.b64decode(cookie))
-    return res
 
 class HttpTokenGlue:
 
@@ -37,9 +29,12 @@ class HttpTokenGlue:
             self.del_cookie(request, response)
             return response
 
-    def set_cookie(self, token: mvp_pb2.AuthToken, response: web.Response) -> mvp_pb2.AuthToken:
-        response.set_cookie(self._AUTH_COOKIE_NAME, _encode_token_for_cookie(token))
+    def set_cookie(self, token: AuthToken, response: web.Response) -> AuthToken:
+        response.set_cookie(self._AUTH_COOKIE_NAME, self._mint.seal_token(token))
         return token
+
+    def set_cookie_for_owner(self, owner: Username, response: web.Response) -> AuthToken:
+        return self.set_cookie(self._mint.mint_token(owner), response)
 
     def del_cookie(self, req: web.Request, resp: web.Response) -> None:
         token = self.parse_cookie(req)
@@ -47,15 +42,11 @@ class HttpTokenGlue:
             self._mint.revoke_token(token)
         resp.del_cookie(self._AUTH_COOKIE_NAME)
 
-    def parse_cookie(self, req: web.Request) -> Optional[mvp_pb2.AuthToken]:
+    def parse_cookie(self, req: web.Request) -> Optional[AuthToken]:
         cookie = req.cookies.get(self._AUTH_COOKIE_NAME)
         if cookie is None:
             return None
-        try:
-            token = _decode_token_from_cookie(cookie)
-        except ValueError:
-            return None
-
+        token = self._mint.unseal_token(cookie)
         return None if (self._mint.check_token(token) is None) else token
 
     def get_authorizing_user(self, req: web.Request) -> Optional[AuthorizingUsername]:

--- a/server/sql_servicer.py
+++ b/server/sql_servicer.py
@@ -783,9 +783,11 @@ class SqlServicer(Servicer):
             raise BadCredentialsError('bad password')
 
         logger.debug('username logged in', username=request.username)
-        token = self._token_mint.mint_token(owner=Username(request.username), ttl_seconds=60*60*24*365)
+        # The AuthSuccess carries the username so the client knows who it's now
+        # logged in as; the actual signed session cookie is minted by the
+        # transport (api_server), which owns cookies.
         return mvp_pb2.AuthSuccess(
-          token=token,
+          token=mvp_pb2.AuthToken(owner=Username(request.username)),
           user_info=self._conn.get_settings(AuthorizingUsername(Username(request.username))),
         )
 

--- a/server/test_tokens.py
+++ b/server/test_tokens.py
@@ -1,0 +1,62 @@
+import pytest
+
+from . import tokens
+from .core import TokenMint
+from .test_utils import MockClock
+
+KEY = b'secret for testing'
+
+
+def test_seal_unseal_roundtrips():
+    t = tokens.AuthToken(owner='alice', minted_unixtime=1000, expires_unixtime=2000)
+    sealed = tokens.seal(KEY, t)
+    assert tokens.unseal(KEY, sealed, tokens.AuthToken) == t
+
+
+def test_unseal_rejects_wrong_key():
+    sealed = tokens.seal(KEY, tokens.AuthToken(owner='alice', minted_unixtime=1000, expires_unixtime=2000))
+    assert tokens.unseal(b'other key', sealed, tokens.AuthToken) is None
+
+
+def test_unseal_rejects_tampered_payload():
+    t = tokens.AuthToken(owner='alice', minted_unixtime=1000, expires_unixtime=2000)
+    payload_b64, mac_b64 = tokens.seal(KEY, t).split('.', 1)
+    # forge a different owner but keep the original MAC
+    forged_payload = tokens._b64(
+        tokens.AuthToken(owner='mallory', minted_unixtime=1000, expires_unixtime=2000)
+        .model_dump_json().encode()
+    )
+    assert tokens.unseal(KEY, f'{forged_payload}.{mac_b64}', tokens.AuthToken) is None
+
+
+@pytest.mark.parametrize('garbage', ['', 'nodot', 'not.base64!!', '.', 'YQ.YQ'])
+def test_unseal_rejects_garbage(garbage):
+    assert tokens.unseal(KEY, garbage, tokens.AuthToken) is None
+
+
+# --- TokenMint policy: minting and the expiry window ---
+
+def test_mint_and_check_token_within_window():
+    clock = MockClock()
+    mint = TokenMint(KEY, clock=clock.now)
+    token = mint.mint_token('alice', ttl_seconds=100)
+    assert mint.check_token(token) == 'alice'
+    clock.tick(99)
+    assert mint.check_token(token) == 'alice'
+    clock.tick(2)  # now past expiry
+    assert mint.check_token(token) is None
+
+
+def test_check_token_rejects_none():
+    assert TokenMint(KEY).check_token(None) is None
+
+
+def test_sealed_token_survives_a_fresh_mint_with_the_same_key():
+    # Different TokenMint instance, same secret -> a cookie sealed by one is
+    # accepted by another (this is what makes stateless cookies work).
+    clock = MockClock()
+    sealed = TokenMint(KEY, clock=clock.now).seal_token(
+        TokenMint(KEY, clock=clock.now).mint_token('alice', ttl_seconds=100)
+    )
+    other = TokenMint(KEY, clock=clock.now)
+    assert other.check_token(other.unseal_token(sealed)) == 'alice'

--- a/server/tokens.py
+++ b/server/tokens.py
@@ -1,0 +1,60 @@
+"""Signed tokens the server issues and later verifies: the auth cookie, and
+(soon) the email-verification proof.
+
+A token is a Pydantic model serialized to JSON and stamped with an HMAC, so the
+server can hand it out and trust it when it comes back. `seal`/`unseal` are the
+generic mechanism; `AuthToken` is the first model to use it.
+
+The sealed form is tamper-evident, NOT secret: the payload is plain readable
+JSON. Never put anything in a token that the bearer shouldn't see.
+"""
+
+import base64
+import hmac
+from typing import Optional, Type, TypeVar
+
+from pydantic import BaseModel
+
+
+class AuthToken(BaseModel):
+    owner: str
+    minted_unixtime: float
+    expires_unixtime: float
+
+
+_Model = TypeVar("_Model", bound=BaseModel)
+
+
+def _mac(secret_key: bytes, payload: bytes) -> bytes:
+    return hmac.digest(secret_key, payload, "sha256")
+
+
+def _b64(b: bytes) -> str:
+    return base64.urlsafe_b64encode(b).decode("ascii")
+
+
+def _unb64(s: str) -> bytes:
+    return base64.urlsafe_b64decode(s)
+
+
+def seal(secret_key: bytes, model: BaseModel) -> str:
+    """`<payload>.<hmac>`, both url-safe base64. Verify with `unseal`."""
+    payload = model.model_dump_json().encode("utf-8")
+    return _b64(payload) + "." + _b64(_mac(secret_key, payload))
+
+
+def unseal(secret_key: bytes, sealed: str, cls: Type[_Model]) -> Optional[_Model]:
+    """Inverse of `seal`. None if the shape is wrong, the HMAC doesn't verify,
+    or the payload isn't valid for `cls`."""
+    try:
+        payload_b64, mac_b64 = sealed.split(".", 1)
+        payload = _unb64(payload_b64)
+        mac = _unb64(mac_b64)
+    except Exception:
+        return None
+    if not hmac.compare_digest(mac, _mac(secret_key, payload)):
+        return None
+    try:
+        return cls.model_validate_json(payload)
+    except Exception:
+        return None

--- a/server/web_server.py
+++ b/server/web_server.py
@@ -14,6 +14,7 @@ from PIL import Image, ImageDraw, ImageFont  # type: ignore
 import structlog
 
 from .core import ApiError, AuthorizingUsername, Servicer, TokenMint, Username, token_owner
+from .tokens import AuthToken
 from .http_glue import HttpTokenGlue
 from .protobuf import mvp_pb2
 
@@ -100,7 +101,7 @@ class WebServer:
         )
         self._jinja.undefined = jinja2.StrictUndefined  # raise exception if a template uses an undefined variable; adapted from https://stackoverflow.com/a/39127941/8877656
 
-    def _get_auth_success(self, auth: Optional[mvp_pb2.AuthToken], req: mvp_pb2.GetSettingsRequest = mvp_pb2.GetSettingsRequest()) -> Optional[mvp_pb2.AuthSuccess]:
+    def _get_auth_success(self, auth: Optional[AuthToken], req: mvp_pb2.GetSettingsRequest = mvp_pb2.GetSettingsRequest()) -> Optional[mvp_pb2.AuthSuccess]:
         if auth is None:
             return None
         try:
@@ -108,7 +109,7 @@ class WebServer:
         except ApiError as e:
             logger.error('failed to get settings for valid-looking user', data_loss=True, auth=auth, error=e.catchall)
             return None
-        return mvp_pb2.AuthSuccess(token=auth, user_info=user_info)
+        return mvp_pb2.AuthSuccess(token=mvp_pb2.AuthToken(owner=auth.owner), user_info=user_info)
 
     async def get_static(self, req: web.Request) -> web.StreamResponse:
         filename = req.match_info['filename']


### PR DESCRIPTION
**Phase 2a** of replacing Protobuf with Pydantic+FastAPI (spike #34, config was #38).

I split Phase 2 (tokens) into **2a (this PR): the auth session cookie** and **2b (next): the email-verification proof**. The cookie is purely server-side, so it migrates cleanly with no Elm and no wire change. The email proof genuinely round-trips through the client (email link → InitUser → register request), so migrating it needs wire + Elm changes — a different, larger change that would make one PR sprawl across the registration UI.

## What changed

The auth cookie was `base64(AuthToken.SerializeToString())`, HMAC'd over a protobuf-serialized scratchpad. It's now a **sealed Pydantic token**: a JSON payload plus an HMAC, encoded as `<b64>.<b64>`.

- **`server/tokens.py`** — Pydantic `AuthToken` + a generic `seal`/`unseal` (HMAC-SHA256 over the JSON payload, `hmac.compare_digest` on the way back). Tamper-evident, not secret — same trust model as before.
- **`core.TokenMint`** — mints/seals/unseals/expiry-checks the Pydantic token; the protobuf signing helpers (`_sign_token`, `_compute_token_hmac`) are gone. Proof-of-email signing stays on protobuf for now (that's 2b).
- **`http_glue`** — the cookie is the sealed token; `parse_cookie` unseals and checks the expiry window.
- **The cookie is now a transport concern.** `api_server` mints it from the logged-in username, rather than the servicer. `sql_servicer.LogInUsername` just reports *who* logged in — its `AuthSuccess.token` carries only `.owner` (all Elm ever reads). `web_server` rebuilds a proto `AuthToken(owner=...)` for the pages it server-renders.

**No proto changes, no Elm changes.** `AuthToken` stays in the proto as a wire-side owner-carrier until Phase 3 removes it.

## Sessions terminated

Old proto-format cookies no longer unseal, so **every existing session is logged out** — you approved this. (The signing secret is unchanged; it's the cookie *encoding* that changed.)

## Verification

- `pytest`: **242 passed** (+10 in `test_tokens.py` — seal/unseal round-trip, wrong-key, tampered-payload, garbage input, expiry window, cross-instance). The 2 failures are the pre-existing `elm/dist`-not-built ones. `test_http_glue` needed no changes — the sealing API stayed compatible.
- `mypy`: **21** — unchanged from master.
- No Elm run: nothing client-facing (proto or `.elm`) changed.
- **Booted the real server** and drove the auth flow: register/login sets a cookie whose payload decodes to readable JSON (`{"owner": "...", "minted_unixtime": ..., "expires_unixtime": ...}`), that cookie authenticates a follow-up `Whoami`, and a hand-forged old proto-format cookie is rejected.

## Next

- **2b:** email-verification proof (`ProofOfEmail`) → Pydantic. Touches the email link, the InitUser page flags, `RegisterUsernameRequest`, and `InitUser.elm` — the registration flow.
- **Phase 3:** the API — Pydantic request/response models + FastAPI + Elm regenerated from OpenAPI; delete the `protoc` toolchain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
